### PR TITLE
Use float instead of np.float alias

### DIFF
--- a/mordred/ABCIndex.py
+++ b/mordred/ABCIndex.py
@@ -53,7 +53,7 @@ class ABCIndex(ABCIndexBase):
         return np.sqrt((du + dv - 2.0) / (du * dv))
 
     def calculate(self):
-        return np.float(np.sum(self._each_bond(bond) for bond in self.mol.GetBonds()))
+        return float(np.sum(self._each_bond(bond) for bond in self.mol.GetBonds()))
 
 
 class ABCGGIndex(ABCIndexBase):

--- a/mordred/MoRSE.py
+++ b/mordred/MoRSE.py
@@ -83,6 +83,6 @@ class MoRSE(Descriptor):
 
         np.fill_diagonal(n, 0)
 
-        return np.float(0.5 * A.dot(n).dot(A.T))
+        return float(0.5 * A.dot(n).dot(A.T))
 
     rtype = float


### PR DESCRIPTION
The confusing np.float alias has been deprecated since 1.20 and removed in 1.24, see
https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated